### PR TITLE
Fix week 7 lab ids and repo links

### DIFF
--- a/7_ml/__labs_shortcuts_md__/lab_hyperparameter_tuning.md
+++ b/7_ml/__labs_shortcuts_md__/lab_hyperparameter_tuning.md
@@ -1,3 +1,3 @@
 <br><br>
 
-Labs are stored on GitHub, so follow the link to get there: [Lab | Hyperparameter Tuning](https://github.com/data-bootcamp-v4/lab-hyperparameter_tuning).
+Labs are stored on GitHub, so follow the link to get there: [Lab | Hyperparameter Tuning](https://github.com/data-bootcamp-v4/lab-hyperparameter-tuning).

--- a/index.yaml
+++ b/index.yaml
@@ -1438,7 +1438,7 @@ course:
                   file: 7_ml/__labs_shortcuts_md__/lab_ensemble.md
                 - type: deliverable
                   display_name: ensemble
-                  deliverable_identifier: lab_ensemble
+                  deliverable_identifier: lab-ensemble
                   deliverable_description: Submit the url to your work below
                   deliverable_duedate: ""
                   deliverable_required: true


### PR DESCRIPTION
- Updated `index.yaml` and the id for the Week 7 "LAB Ensemble"
- Updated `lab_hyperparameter_tuning.md` link to the GitHub repo.